### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :redirect, only: [:edit, :update]
 
   def index
     @items = Item.all.order(created_at: "DESC")
@@ -45,7 +46,7 @@ class ItemsController < ApplicationController
   private
 
   def redirect
-    redirect_to action: :index unless user_signed_in?
+    redirect_to action: :index unless user_signed_in? && current_user.id
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
   private
 
   def redirect
-    redirect_to action: :index unless user_signed_in? && current_user.id
+    redirect_to action: :index unless current_user.id == @item.user_id
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :item_edit, only:[:edit]
-  before_action :item_update, only:[:update]
 
   def index
     @items = Item.all.order(created_at: "DESC")
@@ -26,13 +24,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless item_edit
-      redirect_to root_path
-    end
+
   end
 
   def update
-    unless item_update
+    if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
       render :edit
@@ -48,12 +44,8 @@ class ItemsController < ApplicationController
 
   private
 
-  def item_edit
-    @item_edit = user_signed_in? && current_user.id == @item.user_id
-  end
-
-  def item_update
-    @item_update = user_signed_in? && current_user.id ==  @item.update(item_params)
+  def redirect
+    redirect_to action: :index unless user_signed_in?
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  
+  before_action :item_edit, only:[:edit]
+  before_action :item_update, only:[:update]
+
   def index
     @items = Item.all.order(created_at: "DESC")
   end
@@ -24,13 +26,13 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless user_signed_in? && current_user.id == @item.user_id
+    unless item_edit
       redirect_to root_path
     end
   end
 
   def update
-    if @item.update(item_params)
+    unless item_update
       redirect_to item_path(@item.id)
     else
       render :edit
@@ -45,6 +47,14 @@ class ItemsController < ApplicationController
   # end
 
   private
+
+  def item_edit
+    @item_edit = user_signed_in? && current_user.id == @item.user_id
+  end
+
+  def item_update
+    @item_update = user_signed_in? && current_user.id ==  @item.update(item_params)
+  end
 
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,19 +23,19 @@ class ItemsController < ApplicationController
       end
   end
 
-  # def edit
-  #   unless user_signed_in? && current_user.id == @item.user_id
-  #     redirect_to root_path
-  #   end
-  # end
+  def edit
+    unless user_signed_in? && current_user.id == @item.user_id
+      redirect_to root_path
+    end
+  end
 
-  # def update
-  #   if @item.update(item_params)
-  #     redirect_to item_path(@item.id)
-  #   else
-  #     render :edit
-  #   end
-  # end
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
+  end
 
   # def destroy
   #   if user_signed_in? && current_user.id == @item.user_id

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with model: @item, url: item_path, local: true, method: :patch do |f| %> %>
+    <%= form_with model: @item, url: item_path, local: true, method: :patch do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
     


### PR DESCRIPTION
# what
商品情報の編集機能
# why
フリマアプリで出品した商品の情報を編集するため

## 画像一覧

* 何も編集せずに更新をしても画像無しの商品にならないこと
* 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
*商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
* https://gyazo.com/694fcd923b761fda2fedcc9dcfdc045e

* 必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
* https://gyazo.com/35c9b8e9cc25ac172bcc0fcc3f7b8f58

* ログイン状態の出品者だけが商品情報編集ページに遷移できること
* https://gyazo.com/52217fc9c6e853a45ad27eae2f9b8cbd

* ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
* https://gyazo.com/f0d8d4e3eb44874c2a674935ca8c6736

* ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
* https://gyazo.com/c29b9a1aecd244bdfa7385cb3b249c78

* エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させること）
* エラーメッセージの出力は、商品情報編集ページにて行うこと
* https://gyazo.com/56acd6fe0e01aa810f8ea97e492122fa